### PR TITLE
[PUBLISHED] 113 - Override mongo_url setting for e2e test

### DIFF
--- a/2-structured-data/test/lib/E2EDeploymentTrait.php
+++ b/2-structured-data/test/lib/E2EDeploymentTrait.php
@@ -39,6 +39,7 @@ trait E2EDeploymentTrait
     private static function dumpConfig()
     {
         $config = self::getConfig();
+        $config['mongo_url'] = getenv('MONGO_E2E_URL');
         $dumper = new Dumper();
         $yaml = $dumper->dump($config);
         // TODO: Use different filename

--- a/3-cloud-storage/test/lib/E2EDeploymentTrait.php
+++ b/3-cloud-storage/test/lib/E2EDeploymentTrait.php
@@ -39,6 +39,7 @@ trait E2EDeploymentTrait
     private static function dumpConfig()
     {
         $config = self::getConfig();
+        $config['mongo_url'] = getenv('MONGO_E2E_URL');
         $dumper = new Dumper();
         $yaml = $dumper->dump($config);
         // TODO: Use different filename

--- a/4-auth/test/lib/E2EDeploymentTrait.php
+++ b/4-auth/test/lib/E2EDeploymentTrait.php
@@ -39,6 +39,7 @@ trait E2EDeploymentTrait
     private static function dumpConfig()
     {
         $config = self::getConfig();
+        $config['mongo_url'] = getenv('MONGO_E2E_URL');
         $dumper = new Dumper();
         $yaml = $dumper->dump($config);
         // TODO: Use different filename

--- a/5-logging/test/lib/E2EDeploymentTrait.php
+++ b/5-logging/test/lib/E2EDeploymentTrait.php
@@ -39,6 +39,7 @@ trait E2EDeploymentTrait
     private static function dumpConfig()
     {
         $config = self::getConfig();
+        $config['mongo_url'] = getenv('MONGO_E2E_URL');
         $dumper = new Dumper();
         $yaml = $dumper->dump($config);
         // TODO: Use different filename

--- a/6-compute-engine/test/lib/E2EDeploymentTrait.php
+++ b/6-compute-engine/test/lib/E2EDeploymentTrait.php
@@ -39,6 +39,7 @@ trait E2EDeploymentTrait
     private static function dumpConfig()
     {
         $config = self::getConfig();
+        $config['mongo_url'] = getenv('MONGO_E2E_URL');
         $dumper = new Dumper();
         $yaml = $dumper->dump($config);
         // TODO: Use different filename


### PR DESCRIPTION
This is needed because we use VMs' instnace tag for the firewall rule and when we do that, we need to use the mongodb server's internal IP address, while we still need to use external IP address for the functional tests.