### PR TITLE
Fix Worker to submit valid messages for acknowledgeBatch

### DIFF
--- a/6-pubsub/test/unit/PubSub/WorkerTest.php
+++ b/6-pubsub/test/unit/PubSub/WorkerTest.php
@@ -16,6 +16,8 @@
  */
 namespace Google\Cloud\Samples\Bookshelf\PubSub;
 
+use Google\Cloud\PubSub\Message;
+
 class WorkerTest extends \PHPUnit_Framework_TestCase
 {
     public function testInvoke()
@@ -39,9 +41,10 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         $subscription = $this->getMockBuilder('Google\Cloud\PubSub\Subscription')
             ->disableOriginalConstructor()
             ->getMock();
+        $pubSubMessage = new Message(['attributes' => ['id' => $bookId]], array('ackId' => $ackId));
         $subscription->expects($this->once())
             ->method('acknowledgeBatch')
-            ->with([$ackId]);
+            ->with([$pubSubMessage]);
         $promise = $this->getMockBuilder('GuzzleHttp\Promise\PromiseInterface')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
The example was broken because the 
```
$subscription->acknowledgeBatch()
```
method expects to receive an array of `Google\Cloud\PubSub\Message` objects, not just the Ids.