### PR TITLE
Should MySQL be included in the options?

### DIFF
--- a/2-structured-data/config/settings.yml.dist
+++ b/2-structured-data/config/settings.yml.dist
@@ -3,7 +3,7 @@ google_client_id:      YOUR_CLIENT_ID
 google_client_secret:  YOUR_CLIENT_SECRET
 google_project_id:     YOUR_PROJECT_ID
 
-# options are "mysql", "postgres", "mongodb", or "datastore"
+# options are "cloudsql", "mongodb", or "datastore"
 bookshelf_backend: mysql
 
 # configure CloudSQL for MySQL or PostgreSQL backend


### PR DESCRIPTION
If so, then it should be updated on the following page.  https://cloud.google.com/php/getting-started/using-cloud-sql-with-mysql