### PR TITLE
Update worker.yaml

### DIFF
--- a/6-pubsub/worker.yaml
+++ b/6-pubsub/worker.yaml
@@ -1,5 +1,5 @@
 runtime: php
-vm: true
+env: flex
 service: worker
 # [START entrypoint]
 entrypoint: php bin/pubsub/entrypoint.php


### PR DESCRIPTION
According to `gcloud` Deploymnets using `vm`have been deprecated. Have replaced with `env:flex`