### PR TITLE
test: make cloud-tools dep global

### DIFF
--- a/.kokoro/system_tests.sh
+++ b/.kokoro/system_tests.sh
@@ -52,6 +52,9 @@ if [ "$PULL_REQUEST_NUMBER" != "" ]; then
   export RUN_DEPLOYMENT_TESTS=""
 fi
 
+# Install google/cloud-tools globally
+composer global require google/cloud-tools:dev-master
+
 # Install composer in all directories containing composer.json
 find . -name composer.json -not -path '*vendor/*' -exec dirname {} \; | while read COMPOSER_DIR
 do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ globally:
 composer global require phpunit/phpunit:^7
 ```
 
+These tests also use `google/cloud-tools:dev-master`. You can install this with
+composer globally:
+
+```
+composer global require google/cloud-tools:dev-master
+```
+
 Now you can run the tests in the samples directory!
 
 ```

--- a/authenticate-users/composer.json
+++ b/authenticate-users/composer.json
@@ -5,8 +5,5 @@
         "google/cloud-core": "^1.32",
         "ralouphie/getallheaders": "^3.0",
         "kelvinmo/simplejwt": "^0.2.5"
-    },
-    "require-dev": {
-        "google/cloud-tools": "dev-master"
     }
 }

--- a/background-processing/app/composer.json
+++ b/background-processing/app/composer.json
@@ -3,8 +3,5 @@
     "google/cloud-pubsub": "^1.16",
     "google/cloud-firestore": "^1.7",
     "laravel/lumen-framework": " 5.8.*"
-  },
-  "require-dev": {
-    "google/cloud-tools": "dev-master"
   }
 }

--- a/bookshelf/composer.json
+++ b/bookshelf/composer.json
@@ -9,8 +9,7 @@
   },
   "require-dev": {
     "symfony/dom-crawler": "^5.0.0",
-    "symfony/css-selector": "^5.0.0",
-    "google/cloud-tools": "dev-master"
+    "symfony/css-selector": "^5.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/gce/composer.json
+++ b/gce/composer.json
@@ -1,8 +1,5 @@
 {
   "require": {
     "laravel/lumen-framework": " 5.8.*"
-  },
-  "require-dev": {
-    "google/cloud-tools": "dev-master"
   }
 }

--- a/sessions/composer.json
+++ b/sessions/composer.json
@@ -1,8 +1,5 @@
 {
     "require": {
         "google/cloud-firestore": "^1.9"
-    },
-    "require-dev": {
-        "google/cloud-tools": "dev-master"
     }
 }


### PR DESCRIPTION
This will make the `composer.json` which gets included in our docs not contain dev/test dependencies