### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Platform. Please follow the tutorials for instructions on using these samples.
   * [Session handling with PHP][sessions]
   * [Background Processing for PHP][background-processing]
 
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples).
+
 ## Contributing changes
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.

This is for the benefit of the users, in navigating available Google Cloud code samples.