### PR TITLE
update php version to support Cloud Run buildpack deployment

### DIFF
--- a/bookshelf/composer.json
+++ b/bookshelf/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": ">=7",
+    "php": "^7.1.3",
     "laravel/lumen-framework": "5.8.*",
     "google/cloud-storage": "^1.11",
     "google/cloud-firestore": "^1.2",


### PR DESCRIPTION
Deploying bookshelf app as buildpack to Cloud Run:
```gcloud run deploy bookshelf --region us-central1 --allow-unauthenticated --set-env-vars="GOOGLE_CLOUD_PROJECT=${PROJECT}" --source .```


the following error occurs in the build log: 
```laravel/lumen-framework[v5.8.0, ..., v5.8.13] require php ^7.1.3 ```

This PR changes the php version in order to circumvent.  Fixes #253 