### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/background-processing/backend/Dockerfile
+++ b/background-processing/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir .googleconfig && \
 
 # Copy over composer files and run "composer install"
 COPY composer.* php.ini ./
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin
+COPY --from=composer/composer:1-bin /composer /usr/local/bin
 RUN composer install --no-dev
 
 # Copy over all application files


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
